### PR TITLE
Fix export for Etherpad 1.7.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ exports.stylesForExport = function(hook, padId, cb){
 exports.getLineHTMLForExport = function (hook, context) {
   var header = _analyzeLine(context.attribLine, context.apool);
   if (header) {
+    context.lineContent = "<" + header + ">" + Security.escapeHTML(context.text.substring(1)) + "</" + header + ">";
     return "<" + header + ">" + Security.escapeHTML(context.text.substring(1)) + "</" + header + ">";
   }
 }


### PR DESCRIPTION
Etherpad 1.7.0 getLineHTMLForExport hook doesn't use a return value anymore (see
https://github.com/ether/etherpad-lite/blob/1.7.0/src/node/utils/ExportHtml.js#L454)
but let the plugins modify context.lineContent.