### PR TITLE
Fix backend tests to resolve `Resolution method is overspecified.`

### DIFF
--- a/static/tests/backend/specs/exportHTML.js
+++ b/static/tests/backend/specs/exportHTML.js
@@ -51,21 +51,18 @@ describe('ep_headings2 - export headings to HTML', function () {
       html = () => buildHTML('<h1>Hello world</h1>');
     });
 
-    it('returns ok', async function (done) {
-      agent.get(getHTMLEndPointFor(padID))
+    it('returns ok', async function () {
+      await agent.get(getHTMLEndPointFor(padID))
         .set("Authorization", await generateJWTToken())
         .expect('Content-Type', /json/)
-        .expect(200, done);
+        .expect(200);
     });
 
-    it('returns HTML with Headings HTML tags', async function (done) {
-      agent.get(getHTMLEndPointFor(padID))
-        .set("Authorization", await generateJWTToken())
-        .expect((res) => {
-          const html = res.body.data.html;
-          if (html.indexOf('<h1>Hello world</h1>') === -1) throw new Error('No H1 tag detected');
-        })
-        .end(done);
+    it('returns HTML with Headings HTML tags', async function () {
+      const res = await agent.get(getHTMLEndPointFor(padID))
+        .set("Authorization", await generateJWTToken());
+      const html = res.body.data.html;
+      if (html.indexOf('<h1>Hello world</h1>') === -1) throw new Error('No H1 tag detected');
     });
   });
 
@@ -74,22 +71,19 @@ describe('ep_headings2 - export headings to HTML', function () {
       html = () => buildHTML('<h1>Hello world</h1><br/><h2>Foo</h2>');
     });
 
-    it('returns ok', async function (done) {
-      agent.get(getHTMLEndPointFor(padID))
+    it('returns ok', async function () {
+      await agent.get(getHTMLEndPointFor(padID))
         .set("Authorization", await generateJWTToken())
         .expect('Content-Type', /json/)
-        .expect(200, done);
+        .expect(200);
     });
 
-    it('returns HTML with Multiple Headings HTML tags', async function (done) {
-      agent.get(getHTMLEndPointFor(padID))
+    it('returns HTML with Multiple Headings HTML tags', async function () {
+      const res = await agent.get(getHTMLEndPointFor(padID))
         .set("Authorization", await generateJWTToken())
-        .expect((res) => {
-          const html = res.body.data.html;
-          if (html.indexOf('<h1>Hello world</h1>') === -1) throw new Error('No H1 tag detected');
-          if (html.indexOf('<h2>Foo</h2>') === -1) throw new Error('No H2 tag detected');
-        })
-        .end(done);
+      const html = res.body.data.html;
+      if (html.indexOf('<h1>Hello world</h1>') === -1) throw new Error('No H1 tag detected');
+      if (html.indexOf('<h2>Foo</h2>') === -1) throw new Error('No H2 tag detected');
     });
   });
 
@@ -98,35 +92,31 @@ describe('ep_headings2 - export headings to HTML', function () {
       html = () => buildHTML('<h1><left>Hello world</left></h1><br/><h2><center>Foo</center></h2>');
     });
 
-    it('returns ok', async function (done) {
-      agent.get(getHTMLEndPointFor(padID))
+    it('returns ok', async function () {
+      await agent.get(getHTMLEndPointFor(padID))
         .set("Authorization", await generateJWTToken())
         .expect('Content-Type', /json/)
-        .expect(200, done);
+        .expect(200);
     });
 
-    it('returns HTML with Multiple Headings HTML tags', async function (done) {
+    it('returns HTML with Multiple Headings HTML tags', async function () {
       try {
         // eslint-disable-next-line n/no-extraneous-require, n/no-missing-require
         require.resolve('ep_align');
-        agent.get(getHTMLEndPointFor(padID))
-          .set("Authorization", await generateJWTToken())
-          .expect((res) => {
-            const html = res.body.data.html;
-            console.warn('HTML', html);
-            if (html.indexOf('<h1 style=\'text-align:left\'>Hello world</h1>') === -1) {
-              throw new Error('No H1 tag detected');
-            }
-            if (html.indexOf('<h2 style=\'text-align:center\'>Foo</h2>') === -1) {
-              throw new Error('No H2 tag detected');
-            }
-          })
-          .end(done);
+        const res = await agent.get(getHTMLEndPointFor(padID))
+          .set("Authorization", await generateJWTToken());
+        const html = res.body.data.html;
+        console.warn('HTML', html);
+        if (html.indexOf('<h1 style=\'text-align:left\'>Hello world</h1>') === -1) {
+          throw new Error('No H1 tag detected');
+        }
+        if (html.indexOf('<h2 style=\'text-align:center\'>Foo</h2>') === -1) {
+          throw new Error('No H2 tag detected');
+        }
       } catch (e) {
         if (e.message.indexOf('Cannot find module') === -1) {
           throw new Error(e.message);
         }
-        done();
       }
     });
   });

--- a/static/tests/backend/specs/exportHTML.js
+++ b/static/tests/backend/specs/exportHTML.js
@@ -107,10 +107,10 @@ describe('ep_headings2 - export headings to HTML', function () {
           .set("Authorization", await generateJWTToken());
         const html = res.body.data.html;
         console.warn('HTML', html);
-        if (html.indexOf('<h1 style=\'text-align:left\'>Hello world</h1>') === -1) {
+        if (html.search(/<h1 +style='text-align:left'>Hello world<\/h1>/) === -1) {
           throw new Error('No H1 tag detected');
         }
-        if (html.indexOf('<h2 style=\'text-align:center\'>Foo</h2>') === -1) {
+        if (html.search(/<h2 +style='text-align:center'>Foo<\/h2>/) === -1) {
           throw new Error('No H2 tag detected');
         }
       } catch (e) {


### PR DESCRIPTION
The [backend test of etherpad-lite](https://github.com/ether/etherpad-lite/actions/runs/9175232874/job/25234196727?pr=6396#step:13:1783) was outputting the error like below:

```
  5) ep_headings2 - export headings to HTML
       when pad text has one Heading
         returns ok:
     Error: Resolution method is overspecified. Specify a callback *or* return a Promise; not both.
      at Test.assert (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/supertest@7.0.0/node_modules/supertest/lib/test.js:172:8)
      at localAssert (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/supertest@7.0.0/node_modules/supertest/lib/test.js:120:14)
      at /home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/supertest@7.0.0/node_modules/supertest/lib/test.js:125:7
      at callback (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/superagent@9.0.2/node_modules/superagent/src/node/index.js:887:12)
      at <anonymous> (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/superagent@9.0.2/node_modules/superagent/src/node/index.js:1165:18)
      at IncomingMessage.<anonymous> (/home/runner/work/etherpad-lite/etherpad-lite/node_modules/.pnpm/superagent@9.0.2/node_modules/superagent/src/node/parsers/json.js:19:7)
      at IncomingMessage.emit (node:events:531:35)
      at IncomingMessage.emit (node:domain:488:12)
      at endReadableNT (node:internal/streams/readable:1696:12)
      at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```

This is the same cause as the [ep_font_size error](https://github.com/ether/ep_font_size/pull/113), so I fixed this.