### PR TITLE
Fix focus loss after heading selection, add aria + i18n docs

### DIFF
--- a/locales/qqq.json
+++ b/locales/qqq.json
@@ -4,5 +4,11 @@
 			"BryanDavis"
 		]
 	},
-	"ep_headings.style": "{{Identical|Style}}"
+	"ep_headings.style": "Label for the heading style dropdown and its aria-label. {{Identical|Style}}",
+	"ep_headings.normal": "Option to remove heading formatting and return to normal text",
+	"ep_headings.h1": "Option for Heading level 1 (largest)",
+	"ep_headings.h2": "Option for Heading level 2",
+	"ep_headings.h3": "Option for Heading level 3",
+	"ep_headings.h4": "Option for Heading level 4 (smallest)",
+	"ep_headings.code": "Option for monospaced code formatting"
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -27,6 +27,8 @@ exports.postAceInit = (hookName, context) => {
       }, 'insertheading', true);
       hs.val('dummy');
     }
+    // Return focus to the editor after heading selection (fixes #130)
+    context.ace.focus();
   });
 };
 

--- a/static/tests/frontend/specs/test.js
+++ b/static/tests/frontend/specs/test.js
@@ -12,6 +12,38 @@ describe('ep_headings2 - Set Heading and ensure its removed properly', function 
   // Set Line 1 heading and check it's set
   // Set Line 2 to null heading value and check it's set
 
+  it('Heading select has aria-label for accessibility', async function () {
+    this.timeout(60000);
+    const chrome$ = helper.padChrome$;
+    const $select = chrome$('#heading-selection');
+    expect($select.attr('aria-label')).to.not.be(undefined);
+    expect($select.attr('aria-label').length).to.be.greaterThan(0);
+  });
+
+  it('Focus returns to editor after selecting a heading', async function () {
+    this.timeout(60000);
+    const chrome$ = helper.padChrome$;
+    const inner$ = helper.padInner$;
+
+    // Type some text
+    const $firstTextElement = inner$('div').first();
+    $firstTextElement.sendkeys('{selectall}');
+    $firstTextElement.sendkeys('Test focus');
+
+    // Select heading 1
+    chrome$('#heading-selection').val('0');
+    chrome$('#heading-selection').change();
+
+    // Wait for heading to be applied, then check focus is back in the editor
+    await helper.waitForPromise(() => inner$('div').first().find('h1').length === 1);
+
+    // The editor iframe should have focus, not the toolbar
+    const editorHasFocus = inner$('div').first().is(':focus') ||
+        inner$.document.hasFocus() ||
+        $(helper.padOuter$.document).find('iframe[name="ace_inner"]').is(':focus');
+    expect(editorHasFocus).to.be(true);
+  });
+
   it('Option select is changed when heading is changed', async function () {
     this.timeout(60000);
     const chrome$ = helper.padChrome$;

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,6 +1,9 @@
 <li class="separator acl-write"></li>
 <li id="headings" class="acl-write">
-    <select id="heading-selection">
+    <select id="heading-selection"
+            aria-label="Text style"
+            data-l10n-id="ep_headings.style"
+            data-l10n-attr="aria-label">
         <option value="dummy" selected data-l10n-id="ep_headings.style">Style</option>
         <option value="-1" data-l10n-id="ep_headings.normal">Normal</option>
         <option value="0" data-l10n-id="ep_headings.h1">Heading 1</option>


### PR DESCRIPTION
## Summary

- **Fixes #130** — focus now returns to the editor after selecting a heading, so users can keep typing immediately
- Adds `aria-label` to the heading `<select>` element for screen reader accessibility
- Documents all locale keys in `qqq.json` (previously only `ep_headings.style` was documented)

## Changes

- `static/js/index.js`: call `context.ace.focus()` after heading change
- `templates/editbarButtons.ejs`: add `aria-label` and `data-l10n-attr` to select
- `locales/qqq.json`: document all 7 locale keys

## Test plan

- [ ] Select a heading from the dropdown — cursor should remain in the editor
- [ ] Verify screen reader announces "Style" (or localized equivalent) for the dropdown
- [ ] Verify all heading options still apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)