### PR TITLE
ci: pin pnpm to 10.33.0 (action-setup@v6 resolves "10" to an 11.0.0-beta)

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          version: 10.33.0
           run_install: false
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
pnpm/action-setup@v6 + `version: 10` was installing `pnpm v11.0.0-beta.4-1` on the runner. That pre-release's `pnpm version patch` bumps `package.json` but does not create the git tag, so `git push --atomic <branch> vX.Y.Z` fails with `src refspec vX.Y.Z does not match any`. Pin to `10.33.0` so we actually get pnpm 10.