### PR TITLE
feat: register heading tags as server-side block elements

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -16,6 +16,7 @@
         "eejsBlock_editbarMenuLeft": "ep_headings2/index",
         "collectContentPre": "ep_headings2/static/js/shared",
         "collectContentPost": "ep_headings2/static/js/shared",
+        "ccRegisterBlockElements": "ep_headings2/static/js/shared",
         "getLineHTMLForExport": "ep_headings2/index",
         "stylesForExport" : "ep_headings2/index"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/ether/ep_headings2/issues"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.3.2"
+    "ep_plugin_helpers": "^0.5.2"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -8,3 +8,4 @@ const headings = lineAttribute({attr: 'heading', tags});
 
 exports.collectContentPre = headings.collectContentPre;
 exports.collectContentPost = headings.collectContentPost;
+exports.ccRegisterBlockElements = headings.ccRegisterBlockElements;

--- a/static/tests/backend/specs/exportHTML.ts
+++ b/static/tests/backend/specs/exportHTML.ts
@@ -121,4 +121,35 @@ describe('ep_headings2 - export headings to HTML', function () {
       }
     });
   });
+
+  context('when pad has adjacent <h1> and <h2> with no separator', function () {
+    // Regression for ether/etherpad#7568 round-trip. Without server-side
+    // ccRegisterBlockElements registered for the heading tags,
+    // contentcollector treats <h1>/<h2> as inline and adjacent ones
+    // merge into a single pad line.
+    before(async function () {
+      html = () => buildHTML('<h1>Alpha</h1><h2>Beta</h2>');
+    });
+
+    it('keeps each heading on its own line', function (done) {
+      const expected = /<h1>\s*Alpha\s*<\/h1>[\s\S]*<h2>\s*Beta\s*<\/h2>/;
+      generateJWTToken().then((token) => {
+        agent.get(getHTMLEndPointFor(padID))
+            .set('Authorization', token)
+            .end((err, res) => {
+              if (err) return done(err);
+              const out = res.body.data.html;
+              if (out.search(expected) === -1) {
+                return done(new Error(
+                    `Adjacent headings merged or missing in: ${out}`));
+              }
+              if (out.search(/AlphaBeta/) !== -1) {
+                return done(new Error(
+                    `Headings merged into one line: ${out}`));
+              }
+              done();
+            });
+      }).catch(done);
+    });
+  });
 });


### PR DESCRIPTION
Wires the new server-side `ccRegisterBlockElements` hook (added in [`ether/ep_plugin_helpers#14`](https://github.com/ether/ep_plugin_helpers/pull/14)) so the importer treats `h1`–`h4` and `code` as block elements, matching what `aceRegisterBlockElements` already does on the editor side.

## Why

Etherpad core has two independent block-element registries: an editor-side one driven by `aceRegisterBlockElements` and a server-side one driven by `ccRegisterBlockElements`. ep_headings2 only registered the editor side, so contentcollector treated `<h1>`/`<h2>`/`<code>` as inline on the import path and merged adjacent ones into a single pad line. This bit native DOCX import in [`ether/etherpad#7568`](https://github.com/ether/etherpad/pull/7568): mammoth produces `<h1>A</h1><h2>B</h2><p>C</p>`, the importer merged `A` and `B` into one line, and the round-trip lost the structure.

## What

- `static/js/shared.js`: re-export the new `ccRegisterBlockElements` from `lineAttribute`.
- `ep.json`: wire it as a server-side hook.
- `package.json`: bump `ep_plugin_helpers` minimum to `^0.5.2` (the version with the new export).
- `static/tests/backend/specs/exportHTML.ts`: regression test asserting that an adjacent-headings pad (`<h1>Alpha</h1><h2>Beta</h2>`) survives a setHTML / getHTML round-trip with each heading on its own line and no merged "AlphaBeta" content.

CI runs against etherpad core's content collector with this plugin installed, so the new test exercises the full server-side path.

Refs `ether/etherpad#7568`.