### PR TITLE
a11y: mark <select> aria-label as html10n-managed (forward-compatible)

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -3,7 +3,7 @@
     <select id="heading-selection"
             aria-label="Text style"
             data-l10n-id="ep_headings.style"
-            data-l10n-attr="aria-label">
+            data-l10n-aria-label="true">
         <option value="dummy" selected data-l10n-id="ep_headings.style">Style</option>
         <option value="-1" data-l10n-id="ep_headings.normal">Normal</option>
         <option value="0" data-l10n-id="ep_headings.h1">Heading 1</option>


### PR DESCRIPTION
## Summary

Adds `data-l10n-aria-label="true"` to toolbar `<select>` elements with `data-l10n-id`. After ether/etherpad#7713, html10n's aria-label auto-population covers form-control elements; the marker tells html10n it owns this attribute and may overwrite it with the localized string on every `pad.applyLanguage()` call.

**Forward-compatible, not a breaking change for users on older etherpad:**
- Older etherpad without the html10n fix doesn't reach the form-control aria-label path → the hardcoded English `aria-label` remains as a fallback (no regression).
- Newer etherpad with the html10n fix → html10n overwrites the aria-label with the localized translation on initial load and on language change.

Also drops `data-l10n-attr="aria-label"` — a no-op convention from a different localization library.