### PR TITLE
fix(deps): bump ep_plugin_helpers range to ^0.6.1 (follow-up to #184)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/ether/ep_headings2/issues"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.6.0"
+    "ep_plugin_helpers": "^0.6.1"
   },
   "devDependencies": {
     "eslint": "^8.57.1",


### PR DESCRIPTION
Follow-up to https://github.com/ether/ep_headings2/pull/184.

Etherpad's plugin installer resolves the dep range's lower-bound version literally — `^0.6.0` makes it ask npm for `ep_plugin_helpers@0.6.0`, which was never published (auto-publish bumped straight from `0.5.3` to `0.6.1`). CI on master has been red since #184 merged. Same one-line fix being applied across the three migrated plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)